### PR TITLE
Added sorting to the getResourceUpdates action

### DIFF
--- a/src/controller/ResourceUpdateController.php
+++ b/src/controller/ResourceUpdateController.php
@@ -26,7 +26,7 @@ class ResourceUpdateController {
         $out = array();
 
         if (Req::checkIdParam()) {
-            $updates = $this->database->getResourceUpdates($_GET['id'], Req::page());
+            $updates = $this->database->getResourceUpdates($_GET['id'], Req::page(), Req::sorting());
             if (is_null($updates)) return NULL;
 
             foreach ($updates as $update) {

--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -133,13 +133,17 @@ class Database {
         return NULL;
     }
 
-    public function getResourceUpdates($resource_id, $page) {
+    public function getResourceUpdates($resource_id, $page, $sorting = null) {
         $page = $page == 1 ? 0 : 10 * ($page - 1);
 
+        // Default sorting option for this method.
+        if($sorting == null) $sorting = 'asc';
+
         if (!is_null($this->conn)) {
-            $updatesStmt = $this->conn->prepare($this->_resource_update('AND r.resource_id = :resource_id LIMIT 10 OFFSET :offset'));
+            $updatesStmt = $this->conn->prepare($this->_resource_update('AND r.resource_id = :resource_id ORDER BY id :order LIMIT 10 OFFSET :offset'));
             $updatesStmt->bindParam(':resource_id', $resource_id);
             $updatesStmt->bindParam(':offset', $page, \PDO::PARAM_INT);
+            $updatesStmt->bindParam(':order', $sorting, \PDO::PARAM_STR);
 
             if ($updatesStmt->execute()) {
                 return $updatesStmt->fetchAll();

--- a/src/util/RequestUtil.php
+++ b/src/util/RequestUtil.php
@@ -74,6 +74,20 @@ class RequestUtil {
         return 1;
     }
 
+    public static function sorting() {
+        $value = $_GET['sort'] ?? null;
+
+        // Preconditions
+        if($value == null || !is_string($value)) return;
+
+        // Sorting methods
+        if(strcasecmp($value, 'asc')) return 'asc';
+        if(strcasecmp($value, 'desc')) return 'desc';
+
+        // Return default null
+        return NULL;
+    }
+
     public static function category() {
         $value = $_GET['category'] ?? null;
 

--- a/src/util/RequestUtil.php
+++ b/src/util/RequestUtil.php
@@ -84,7 +84,7 @@ class RequestUtil {
         if(strcasecmp($value, 'asc')) return 'asc';
         if(strcasecmp($value, 'desc')) return 'desc';
 
-        // Return default null
+        // Return default null. This allows different defaults per method.
         return NULL;
     }
 


### PR DESCRIPTION
So this is just going by intuition and by looking at the existing code.
This PR is one of the suggestions made in issue #62 

**Added: RequestUtils:sorting()**
Adds the sorting parameter. Returns NULL by default such that controllers can choose their default if required.

**Changed Database->getResourceUpdates() parameters**
Added the parameter `$sorting = null`. Defaults to `asc` which is the default right now I believe.
SQL got changed in order to add support for the sorting param.

### Friendly note
These changes are UNTESTED since I don't have a database to test this on :)