### PR TITLE
openapi: Rename parameter `id` to `name` in findAuthor endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -143,14 +143,14 @@ paths:
                 $ref: '#/components/schemas/Author'
   /index.php?action=findAuthor:
     parameters:
-      - name: id
+      - name: name
         description: The author username
         in: query
         required: true
         schema:
           type: string
     get:
-      summary: Obtain an author/user by their id
+      summary: Obtain an author/user by their name
       responses:
         '200':
           description: An object containing information about an author/user


### PR DESCRIPTION
Fixes the findAuthor endpoint in the openapi.yaml specification file.
As you can read [in the readme](https://github.com/SpigotMC/XenforoResourceManagerAPI?tab=readme-ov-file#findauthor), the endpoint needs the authors name, not their ID.
