### PR TITLE
openapi: Change type of `identities` from `array` to `object`

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -283,8 +283,33 @@ components:
         resource_count:
           type: string
         identities:
-          type: array
-          items:
-            type: string
+          type: object
+          required: []
+          properties:
+            github:
+              type: string
+            discord:
+              type: string
+            youtube:
+              type: string
+            aim:
+              type: string
+            # called "Windows Live" in the UI
+            msn:
+              type: string
+            icq:
+              type: string
+            # called "Yahoo! Messenger" in the UI
+            yahoo:
+              type: string
+            skype:
+              type: string
+            # called "Google Talk" in the UI
+            gtalk:
+              type: string
+            facebook:
+              type: string
+            twitter:
+              type: string
         avatar:
           type: string


### PR DESCRIPTION
Identities are not an array but an object, as you can see in this [example response](https://api.spigotmc.org/simple/0.2/index.php?action=getAuthor&id=1) from the API.

I copied the properties from the [Contact Details section](https://www.spigotmc.org/account/contact-details) from the account settings in spigotmc.org