### PR TITLE
openapi: Remove `sort` parameter from `getResourceUpdates` endpoint

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -114,12 +114,6 @@ paths:
         required: false
         schema:
           type: integer
-      - name: sort
-        description: The method to sort by (default 'asc')
-        in: query
-        required: false
-        schema:
-          type: string
     get:
       operationId: getResourceUpdates
       summary: Obtain all the updates to a resource


### PR DESCRIPTION
The endpoint `getResourceUpdates` does not accept a `sort` parameter.
`getResourceUpdates` only accepts the parameters: `id` and `page`, as described in the [readme](https://github.com/SpigotMC/XenforoResourceManagerAPI?tab=readme-ov-file#getresourceupdates).
This PR removes the `sort` parameter from the `openapi.yaml`.