### PR TITLE
Add `description` property to `category` in `resource` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
     "title":"BungeeLobbyKick",
     "tag":"This plugin will move all players to a configured server on command",
     "current_version":"0.2",
+    "category":{
+      "id":3,
+      "title":"Bungee - Proxy",
+      "description":"Bungee plugins that interact directly with the proxy plugins folder."
+    },
     "native_minecraft_version":null,
     "supported_minecraft_versions":null,
     "icon_link":"https:\/\/www.spigotmc.org\/styles\/default\/xenresource\/resource_icon.png",
@@ -60,6 +65,11 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
     "title":"BungeeKickStop",
     "tag":"Bungee Kick control plugin - move players to a different server when kicked",
     "current_version":"0.1",
+    "category":{
+      "id":3,
+      "title":"Bungee - Proxy",
+      "description":"Bungee plugins that interact directly with the proxy plugins folder."
+    },      
     "native_minecraft_version":null,
     "supported_minecraft_versions":null,
     "icon_link":"https:\/\/www.spigotmc.org\/styles\/default\/xenresource\/resource_icon.png",
@@ -98,6 +108,11 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
   "title":"HubKick",
   "tag":"Send players to lobby on kick. \/lobby \/ hub",
   "current_version":"1.7.1",
+  "category":{
+    "id":2,
+    "title":"Bungee - Spigot",
+    "description":"Spigot plugins that interact with BungeeCord."
+  },    
   "native_minecraft_version":null,
   "supported_minecraft_versions":[
     "1.7",
@@ -140,7 +155,12 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
     "id":"57242",
     "title":"spark",
     "tag":"spark is a performance profiling plugin\/mod for Minecraft clients, servers and proxies.",
-    "current_version":"1.6.1",
+    "current_version":"1.6.1", 
+    "category":{
+      "id":15,
+      "title":"Tools and Utilities",
+      "description":""
+    },
     "native_minecraft_version":"",
     "supported_minecraft_versions":[
       "1.8",
@@ -178,7 +198,12 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
     "id":"28140",
     "title":"LuckPerms",
     "tag":"A permissions plugin for Minecraft servers (Bukkit\/Spigot, BungeeCord & more)",
-    "current_version":"5.3.47",
+    "current_version":"5.3.47", 
+    "category":{
+      "id":21,
+      "title":"Universal",
+      "description":""
+    },
     "native_minecraft_version":"",
     "supported_minecraft_versions":[
       "1.7",

--- a/src/object/Resource.php
+++ b/src/object/Resource.php
@@ -24,9 +24,11 @@ class Resource {
         $this->tag = $resource['tag_line'];
         $this->current_version = $resource['version_string'];
 
-        $category = new \stdClass();
-        $category->id = $resource['resource_category_id'];
-        $category->title = $resource['category_title'];
+        $category = new ResourceCategory([
+            'resource_category_id' => $resource['resource_category_id'],
+            'category_title' => $resource['category_title'],
+            'category_description' => $resource['category_description']
+        ]);
         $this->category = $category;
 
         for ($idx = 0; $idx < count($resource['fields']); $idx++) {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -192,6 +192,8 @@ components:
           type: string
         current_version:
           type: string
+        category:
+          $ref: '#/components/schemas/ResourceCategory'
         native_minecraft_version:
           type: string
           nullable: true

--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -206,7 +206,7 @@ class Database {
 
     private function _resource($suffix) {
         return sprintf(
-            "SELECT r.resource_id, r.title, r.tag_line, r.user_id, r.username, r.price, r.currency, r.download_count, r.update_count, r.rating_count, r.review_count, r.rating_avg, r.icon_date, rv.version_string, rv.download_url, ru.message, rc.resource_category_id, rc.category_title
+            "SELECT r.resource_id, r.title, r.tag_line, r.user_id, r.username, r.price, r.currency, r.download_count, r.update_count, r.rating_count, r.review_count, r.rating_avg, r.icon_date, rv.version_string, rv.download_url, ru.message, rc.resource_category_id, rc.category_title, rc.category_description
             FROM xf_resource r
                 INNER JOIN xf_resource_version rv 
                     ON r.current_version_id = rv.resource_version_id 


### PR DESCRIPTION
When you list resource categories (using `listResourceCategories`), you get an array of objects with the following properties: `id`, `title`, `description`.
When you query a Resource (using `getResource`, `listResources`, ...), it contains an object for the category, but this object only has the properties: `id` and `title`.
This PR unifies the use of the category and uses the `ResourceCategory` object in both places, which has the properties `id`, `title`, `description`.

---

I believe that the resource response should either only return the ID of the category (if the user needs further information  about the category, they can use the `listResourceCategories` endpoint) or the entire object with all properties: `id`, `title`, `description`.
As implemented with this PR, no information is removed, but added. This means that, in my opinion, this is not a breaking change in the API, but a new feature in which an additional field is returned by the API.