### PR TITLE
openapi: Add property `external_download_url` to `Resource` schema

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -231,6 +231,10 @@ components:
                   type: string
             rating:
               type: string
+        external_download_url:
+          type: string
+          format: uri
+          default: ""
         description:
           type: string
     ArrayOfResources:


### PR DESCRIPTION
As you can see in [this API response](https://api.spigotmc.org/simple/0.2/index.php?action=getResource&id=2) or read in [the code of the Resource object](https://github.com/SpigotMC/XenforoResourceManagerAPI/blob/master/src/object/Resource.php#L73), the Resource object contains a property called `external_download_url`. This property is missing in the openapi.yaml. This PR fixes this and adds the `external_download_url` property to the Resource schema.