### PR TITLE
openapi: Change type of `id`s from `string` to `integer`

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -185,7 +185,7 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
         title:
           type: string
         tag:
@@ -205,7 +205,7 @@ components:
           type: object
           properties:
             id:
-              type: string
+              type: integer
             username:
               type: string
         premium:
@@ -248,9 +248,9 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
         resource_id:
-          type: string
+          type: integer
         resource_version:
           type: string
         title:
@@ -272,7 +272,7 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
         title:
           type: string
         description:
@@ -285,7 +285,7 @@ components:
       type: object
       properties:
         id:
-          type: string
+          type: integer
         username:
           type: string
         resource_count:


### PR DESCRIPTION
All IDs are returned as integer values in the json responses from the API but the `openapi.yaml` specifies the IDs as strings.
This PR fixes this and changes the type of `id` properties from `string` to `integer`