### PR TITLE
openapi: Change type to `integer` / `number` for numeric properties

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -219,18 +219,19 @@ components:
           type: object
           properties:
             downloads:
-              type: string
+              type: integer
             updates:
-              type: string
+              type: integer
             reviews:
               type: object
               properties:
                 unique:
-                  type: string
+                  type: integer
                 total:
-                  type: string
+                  type: integer
             rating:
-              type: string
+              type: number
+              format: double
         description:
           type: string
     ArrayOfResources:
@@ -289,7 +290,7 @@ components:
         username:
           type: string
         resource_count:
-          type: string
+          type: integer
         identities:
           type: object
           required: []


### PR DESCRIPTION
The API returns numeric values as numbers, not strings.
The `openapi.yaml` specifies them as strings. 
This PR fixes this and changes the types of all numeric properties from `string` to `integer` or `number` with a format.