### PR TITLE
openapi: Add `format: uri` to properties `icon_link` and `avatar`

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -201,6 +201,7 @@ components:
             type: string
         icon_link:
           type: string
+          format: uri
         author:
           type: object
           properties:
@@ -321,3 +322,4 @@ components:
               type: string
         avatar:
           type: string
+          format: uri


### PR DESCRIPTION
Adds modifier property `format` to the properties `icon_link` and `avatar` to define them as URIs.
Read more about the format property in [the official OpenAPI Specification](https://spec.openapis.org/oas/v3.1.0.html#data-types) and [this JSON Schema Specification](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-7.3.5).