### PR TITLE
openapi: make supported_minecraft_versions nullable

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -201,6 +201,7 @@ components:
           type: array
           items:
             type: string
+          nullable: true
         icon_link:
           type: string
           format: uri


### PR DESCRIPTION
The property `supported_minecraft_versions` can be `null`, an empty array `[]` or an array with items.