### PR TITLE
Code formatting: Use short array syntax

### DIFF
--- a/src/controller/ResourceCategoryController.php
+++ b/src/controller/ResourceCategoryController.php
@@ -12,7 +12,7 @@ class ResourceCategoryController {
     }
     
     public function listResourceCategories() {
-        $out = array();
+        $out = [];
 
         $categories = $this->database->listResourceCategories();
 
@@ -21,7 +21,7 @@ class ResourceCategoryController {
         }
 
         foreach ($categories as $category) {
-            array_push($out, new ResourceCategory($category));
+            $out[] = new ResourceCategory($category);
         }
 
         return $out;

--- a/src/controller/ResourceController.php
+++ b/src/controller/ResourceController.php
@@ -12,7 +12,7 @@ class ResourceController {
     }
     
     public function listResources() {
-        $out = array();
+        $out = [];
 
         $resources = $this->database->listResources(Req::category(), Req::page());
 
@@ -21,7 +21,7 @@ class ResourceController {
         }
 
         foreach ($resources as $resource) {
-            array_push($out, new Resource($resource));
+            $out[] = new Resource($resource);
         }
 
         return $out;
@@ -40,7 +40,7 @@ class ResourceController {
     }
 
     public function getResourcesByAuthor() {
-        $out = array();
+        $out = [];
 
         if (Req::checkIdParam()) {
             $resources = $this->database->getResourcesByUser(Req::id(), Req::page());
@@ -50,7 +50,7 @@ class ResourceController {
             }
 
             foreach ($resources as $resource) {
-                array_push($out, new Resource($resource));
+                $out[] = new Resource($resource);
             }
         }
 

--- a/src/controller/ResourceUpdateController.php
+++ b/src/controller/ResourceUpdateController.php
@@ -23,14 +23,14 @@ class ResourceUpdateController {
     }
 
     public function getResourceUpdates() {
-        $out = array();
+        $out = [];
 
         if (Req::checkIdParam()) {
             $updates = $this->database->getResourceUpdates($_GET['id'], Req::page());
             if (is_null($updates)) return NULL;
 
             foreach ($updates as $update) {
-                array_push($out, new ResourceUpdate($update));
+                $out[] = new ResourceUpdate($update);
             }
         }
 

--- a/src/object/Author.php
+++ b/src/object/Author.php
@@ -26,7 +26,7 @@ class Author {
             $this->last_activity = null;
         }
 
-        $this->identities = array();
+        $this->identities = [];
         if ($author['allow_view_identities'] == 'everyone') {
             for ($idx = 0; $idx < count($identities); $idx ++) {
                 $this->identities[$identities[$idx][0]] = $identities[$idx][1];

--- a/src/object/Error.php
+++ b/src/object/Error.php
@@ -7,10 +7,10 @@ class Error extends JsonResponse {
     private $code;
 
     public function __construct($code, $message) {
-        parent::__construct(array(
+        parent::__construct([
             "code" => $code,
             "message" => $message
-        ));
+        ]);
 
         $this->code = $code;
     }

--- a/src/object/Resource.php
+++ b/src/object/Resource.php
@@ -54,25 +54,25 @@ class Resource {
 
         $this->icon_link = Icons::getResourceIcon($this->id, $resource['icon_date']);
 
-        $this->author = array(
+        $this->author = [
             'id' => $resource['user_id'],
             'username' => $resource['username']
-        );
+        ];
 
-        $this->premium = array(
+        $this->premium = [
             'price' => $resource['price'],
             'currency' => $resource['currency']
-        );
+        ];
 
-        $this->stats = array(
+        $this->stats = [
             'downloads' => $resource['download_count'],
             'updates' => $resource['update_count'],
-            'reviews' => array(
+            'reviews' => [
                 'unique' => $resource['rating_count'],
                 'total' => $resource['review_count']
-            ),
+            ],
             'rating' => strval(round($resource['rating_avg'], 1))
-        );
+        ];
 
         $this->external_download_url = $resource['download_url'];
 

--- a/src/support/Config.php
+++ b/src/support/Config.php
@@ -2,7 +2,7 @@
 defined('_XFRM_API') or exit('No direct script access allowed here.');
 
 class Config {
-    public static $data = array(
+    public static $data = [
         // XenForo database
         'MYSQL_USERNAME' => 'root',
         'MYSQL_PASSWORD' => 'root',
@@ -15,5 +15,5 @@ class Config {
 
         // set PUBLIC_PATH_STATIC to the static asset site, including trailing slash
         'PUBLIC_PATH_STATIC' => "https://static.spigotmc.org/"
-    );
+    ];
 }

--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -17,9 +17,9 @@ class Database {
                 ),
                 $username,
                 $password,
-                array(
+                [
                     \PDO::ATTR_PERSISTENT => true
-                )
+                ]
             );
 
             $this->conn->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_WARNING);

--- a/src/support/Router.php
+++ b/src/support/Router.php
@@ -16,7 +16,7 @@ class Router {
     private $authorController;
 
     public function __construct() {
-        $this->actions = array(
+        $this->actions = [
             "listResources", 
             "getResource", 
             "getResourcesByAuthor", 
@@ -25,7 +25,7 @@ class Router {
             "getResourceUpdates", 
             "getAuthor", 
             "findAuthor"
-        );
+        ];
 
         $database = Database::initializeViaConfig();
 


### PR DESCRIPTION
This PR improves the code formatting by using the short array syntax for:
1. array creation: ```$arr = []``` instead of ```$arr = array()``` 
2. push one element onto the end: ```$arr[] = $element``` instead of ```array_push($arr, $element)```