### PR TITLE
add endpoint for premium resource purchases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_style = space
 insert_final_newline = true
 max_line_length = 120
 tab_width = 4
+
+[openapi.yaml]
+indent_size = 2

--- a/src/controller/ResourceController.php
+++ b/src/controller/ResourceController.php
@@ -1,11 +1,18 @@
 <?php namespace XFRM\Controller;
 defined('_XFRM_API') or exit('No direct script access allowed here.');
 
+use XFRM\Object\Error;
 use XFRM\Object\Resource as Resource;
+use XFRM\Object\ResourcePurchase;
+use XFRM\Support\Database;
+use XFRM\Util\ApiKeyUtil;
 use XFRM\Util\RequestUtil as Req;
 
 class ResourceController
 {
+    /**
+     * @var Database
+     */
     private $database;
 
     public function __construct($database)
@@ -61,4 +68,53 @@ class ResourceController
 
         return $out;
     }
+
+    public function getResourcePurchases()
+    {
+        $resource = $this->_getOwnedPremiumResource();
+        $purchases = $this->database->getResourcePurchases($resource->resource_id, Req::page());
+        if (!is_null($purchases)) {
+            $out = [];
+            foreach ($purchases as $purchase) {
+                $out[] = new ResourcePurchase($purchase);
+            }
+            return $out;
+        }
+        return NULL;
+    }
+
+    public function getResourcePurchaseByUser()
+    {
+        if (!Req::checkUserIdParam()) {
+            return NULL;
+        }
+        $resource = $this->_getOwnedPremiumResource();
+        $purchase = $this->database->getResourcePurchaseByUser($resource->resource_id, Req::userId());
+        if (!is_null($purchase)) {
+            return new ResourcePurchase($purchase);
+        }
+        return NULL;
+    }
+
+    private function _getOwnedPremiumResource()
+    {
+        if (Req::checkIdParam() && Req::checkApiKeyParam()) {
+            $apiKeyOwnerId = ApiKeyUtil::validateApiKey($this->database, Req::apiKey());
+            $resource = $this->database->getResource(Req::id());
+            if (is_null($resource) || $resource === false) {
+                return NULL;
+            }
+            if (empty($resource->currency)) {
+                echo new Error(400, "Not a premium resource.");
+                exit();
+            }
+            if ($resource->user_id !== $apiKeyOwnerId) {
+                echo new Error(403, "No access to requested resource.");
+                exit();
+            }
+            return $resource;
+        }
+        return NULL;
+    }
+
 }

--- a/src/imports.php
+++ b/src/imports.php
@@ -16,6 +16,7 @@ require_once(__DIR__ . '/support/Router.php');
 
 require_once(__DIR__ . '/util/IconUtil.php');
 require_once(__DIR__ . '/util/RequestUtil.php');
+require_once(__DIR__ . '/util/ApiKeyUtil.php');
 
 require_once(__DIR__ . '/controller/AuthorController.php');
 require_once(__DIR__ . '/controller/ResourceController.php');

--- a/src/object/ResourcePurchase.php
+++ b/src/object/ResourcePurchase.php
@@ -1,0 +1,19 @@
+<?php namespace XFRM\Object;
+defined('_XFRM_API') or exit('No direct script access allowed here.');
+
+class ResourcePurchase
+{
+
+    public $resource_id;
+
+    public $user_id;
+
+    public function __construct($database_entry)
+    {
+        // TODO: database structure
+        $this->resource_id = $database_entry->resource_id;
+        $this->user_id = $database_entry->user_id;
+    }
+
+
+}

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -132,6 +132,70 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ResourceUpdate'
+  /index.php?action=getResourcePurchases:
+    parameters:
+      - name: id
+        description: The resource ID
+        in: query
+        required: true
+        schema:
+          type: integer
+      - name: page
+        description: The page of results to get
+        in: query
+        required: false
+        schema:
+          type: integer
+    get:
+      operationId: getResourcePurchases
+      summary: Obtain all purchases of a (premium) resource
+      security:
+        - apiKeyAuthorization: [ ]
+      responses:
+        '200':
+          description: An object containing an array with all purchases / purchasers of the resources
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ResourcePurchase'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+  /index.php?action=getResourcePurchaseByUser:
+    parameters:
+      - name: id
+        description: The resource ID
+        in: query
+        required: true
+        schema:
+          type: integer
+      - name: user_id
+        description: The id of the purchaser
+        in: query
+        required: true
+        schema:
+          type: integer
+    get:
+      operationId: getResourcePurchaseByUser
+      summary: Obtain the details of a purchase made by a specific user for a (premium) resource
+      security:
+        - apiKeyAuthorization: [ ]
+      responses:
+        '200':
+          description: An object containing the details of the purchases of the resources
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourcePurchase'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: The specified user did not buy the resource.
   /index.php?action=getAuthor:
     parameters:
       - name: id
@@ -169,6 +233,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/Author'
 components:
+  securitySchemes:
+    apiKeyAuthorization:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  responses:
+    UnauthorizedError:
+      description: Invalid API Key
+    ForbiddenError:
+      description: No permission to access the resource (API Key does not permit access to given resource).
   schemas:
     Resource:
       type: object
@@ -272,6 +346,15 @@ components:
           type: string
         description:
           type: string
+    ResourcePurchase:
+      type: object
+      properties:
+        resource_id:
+          type: integer
+          description: The ID of the purchases resource
+        user_id:
+          type: integer
+          description: The ID of the user that purchased the resource
     Author:
       type: object
       properties:

--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -30,7 +30,7 @@ class Database
         }
     }
 
-    public static function initializeViaConfig()
+    public static function initializeViaConfig(): Database
     {
         return new Database(
             Config::$data['MYSQL_USERNAME'],
@@ -157,6 +157,46 @@ class Database
         return NULL;
     }
 
+    public function getResourcePurchases($resource_id, $page)
+    {
+        $page = $page == 1 ? 0 : 10 * ($page - 1);
+        if (is_null($this->conn)) {
+            return NULL;
+        }
+        // TODO: I have no clue how the tables look like
+        $statement = $this->conn->prepare(
+            "SELECT whatever 
+                        FROM xf_resource_XXXXX 
+                    WHERE resource_id = :resource_id 
+                    LIMIT 10 OFFSET :offset"
+        );
+        $statement->bindParam(':resource_id', $resource_id);
+        $statement->bindParam(':offset', $page, \PDO::PARAM_INT);
+        if ($statement->execute()) {
+            return $statement->fetchAll();
+        }
+        return NULL;
+    }
+
+    public function getResourcePurchaseByUser($resource_id, $user_id)
+    {
+        if (is_null($this->conn)) {
+            return NULL;
+        }
+        // TODO: I (still) have no clue how the tables look like
+        $statement = $this->conn->prepare(
+            "SELECT whatever, something_else
+                        FROM xf_resource_XXXXX 
+                    WHERE resource_id = :resource_id AND purchaser_id = :user_id"
+        );
+        $statement->bindParam(':resource_id', $resource_id);
+        $statement->bindParam(':user_id', $user_id);
+        if ($statement->execute()) {
+            return $statement->fetch();
+        }
+        return NULL;
+    }
+
     public function getUser($user_id)
     {
         if (!is_null($this->conn)) {
@@ -211,6 +251,26 @@ class Database
             }
         }
 
+        return NULL;
+    }
+
+    /**
+     * @param string $apiKey
+     * @return integer|null
+     */
+    public function getApiKeyOwnerId(string $apiKey)
+    {
+        if (is_null($this->conn)) {
+            return NULL;
+        }
+        $statement = $this->conn->prepare("SELECT user_id FROM xf_api_keys WHERE key = :key LIMIT 1");
+        $statement->bindParam(':key', $apiKey);
+        if ($statement->execute()) {
+            $fetched = $statement->fetch();
+            if (!is_null($fetched) && $fetched !== false) {
+                return $fetched['user_id'];
+            }
+        }
         return NULL;
     }
 

--- a/src/support/Router.php
+++ b/src/support/Router.php
@@ -25,6 +25,8 @@ class Router
             "listResourceCategories",
             "getResourceUpdate",
             "getResourceUpdates",
+            "getResourcePurchases",
+            "getResourcePurchaseByUser",
             "getAuthor",
             "findAuthor"
         ];
@@ -78,6 +80,16 @@ class Router
     private function getResourceUpdates()
     {
         return $this->resourceUpdateController->getResourceUpdates();
+    }
+
+    private function getResourcePurchases()
+    {
+        return $this->resourceController->getResourcePurchases();
+    }
+
+    private function getResourcePurchaseByUser()
+    {
+        return $this->resourceController->getResourcePurchaseByUser();
     }
 
     private function getAuthor()

--- a/src/util/ApiKeyUtil.php
+++ b/src/util/ApiKeyUtil.php
@@ -1,0 +1,25 @@
+<?php namespace XFRM\Util;
+defined('_XFRM_API') or exit('No direct script access allowed here.');
+
+use XFRM\Object\Error;
+use XFRM\Support\Database;
+
+class ApiKeyUtil
+{
+
+    /**
+     * @param $database Database
+     * @param $apiKey string
+     * @return integer the user id of the API keys owner
+     */
+    public static function validateApiKey(Database $database, string $apiKey): int
+    {
+        $userId = $database->getApiKeyOwnerId($apiKey);
+        if (!is_null($userId)) {
+            return $userId;
+        }
+        echo new Error(401, "Invalid API Key.");
+        exit();
+    }
+
+}

--- a/src/util/RequestUtil.php
+++ b/src/util/RequestUtil.php
@@ -70,6 +70,57 @@ class RequestUtil
         return true;
     }
 
+    public static function userId()
+    {
+        $userId = $_GET['user_id'] ?? NULL;
+        if (is_numeric($userId) && $userId > 0) {
+            return $userId;
+        }
+        return NULL;
+    }
+
+    public static function checkUserIdParam() {
+        if (is_null(self::userId())) {
+            echo new Error(400, "User ID not specified. Please specify.");
+            exit();
+        }
+        return true;
+    }
+
+    public static function apiKey()
+    {
+        // getallheaders (apache_request_headers) is supported by the majority of runtimes now (FPM, CGI, nginx, etc.)
+        // given headers are by spec case-insensitive, the array keys will be made lowercase to easily access the value by name.
+        $header = array_change_key_case(getallheaders())['x-api-key'];
+        if (!empty($header)) {
+            return $header;
+        }
+        return NULL;
+    }
+
+    /**
+     * Validates the existence and format of the API-Key <b>without</b> validating its validity.
+     * Making sure that the API Key is valid should be done additionally to retrieve the actual owner of the key.
+     * @return true|void
+     */
+    public static function checkApiKeyParam()
+    {
+        $apiKey = self::apiKey();
+
+        if (is_null($apiKey)) {
+            echo new Error(400, "API Key not specified. Must be provided as X-API-Key header.");
+            exit();
+        }
+
+        // regex matching current API key format (sha256 hash of 32 random bytes in hexadecimal format) as specified in
+        // https://github.com/SpigotMC/XenforoApiKeys/blob/main/upload/library/XenforoApiKeys/Model/ApiKey.php#L71
+        if (!preg_match("/^[0-9a-fA-F]{64}$/", $apiKey)) {
+            echo new Error(401, "Invalid API Key.");
+            exit();
+        }
+        return true;
+    }
+
     public static function page()
     {
         $value = $_GET['page'] ?? null;


### PR DESCRIPTION
fixes #8

Adds 2 endpoints:
1. retrieve all purchases of a premium resource
2. retrieve purchase info of a premium resource purchase by a specific user (validate if a user bought a resource)

I can't really test the change nor do I know the table names and schemas. And I don't really want to pay >$200 USD just for this lol
The API Keys are hopefully correctly implemented.

TODO:

- [ ] Update README (when response data format is finalized)
- [ ] Update Queries and Response Model (requires table name and structure)