### PR TITLE
Refactor `checkIdParam()` & `checkNameParam()` to void functions

### DIFF
--- a/src/controller/AuthorController.php
+++ b/src/controller/AuthorController.php
@@ -15,11 +15,11 @@ class AuthorController
 
     public function getAuthor()
     {
-        if (Req::checkIdParam()) {
-            $author = $this->database->getUser($_GET['id']);
-            if (!is_null($author) && $author !== false) {
-                return new Author($author);
-            }
+        Req::checkIdParam();
+
+        $author = $this->database->getUser(Req::id());
+        if (!is_null($author) && $author !== false) {
+            return new Author($author);
         }
 
         return NULL;
@@ -27,11 +27,11 @@ class AuthorController
 
     public function findAuthor()
     {
-        if (Req::checkNameParam()) {
-            $author = $this->database->findUser($_GET['name']);
-            if (!is_null($author) && $author !== false) {
-                return new Author($author);
-            }
+        Req::checkNameParam();
+
+        $author = $this->database->findUser(Req::name());
+        if (!is_null($author) && $author !== false) {
+            return new Author($author);
         }
 
         return NULL;

--- a/src/controller/ResourceController.php
+++ b/src/controller/ResourceController.php
@@ -32,12 +32,11 @@ class ResourceController
 
     public function getResource()
     {
-        if (Req::checkIdParam()) {
-            $resource = $this->database->getResource(Req::id());
+        Req::checkIdParam();
 
-            if (!is_null($resource) && $resource !== false) {
-                return new Resource($resource);
-            }
+        $resource = $this->database->getResource(Req::id());
+        if (!is_null($resource) && $resource !== false) {
+            return new Resource($resource);
         }
 
         return NULL;
@@ -45,18 +44,16 @@ class ResourceController
 
     public function getResourcesByAuthor()
     {
+        Req::checkIdParam();
+
+        $resources = $this->database->getResourcesByUser(Req::id(), Req::page());
+        if (is_null($resources)) {
+            return NULL;
+        }
+
         $out = [];
-
-        if (Req::checkIdParam()) {
-            $resources = $this->database->getResourcesByUser(Req::id(), Req::page());
-
-            if (is_null($resources)) {
-                return NULL;
-            }
-
-            foreach ($resources as $resource) {
-                $out[] = new Resource($resource);
-            }
+        foreach ($resources as $resource) {
+            $out[] = new Resource($resource);
         }
 
         return $out;

--- a/src/controller/ResourceUpdateController.php
+++ b/src/controller/ResourceUpdateController.php
@@ -15,11 +15,11 @@ class ResourceUpdateController
 
     public function getResourceUpdate()
     {
-        if (Req::checkIdParam()) {
-            $update = $this->database->getResourceUpdate($_GET['id']);
-            if (!is_null($update) && $update !== false) {
-                return new ResourceUpdate($update);
-            }
+        Req::checkIdParam();
+
+        $update = $this->database->getResourceUpdate(Req::id());
+        if (!is_null($update) && $update !== false) {
+            return new ResourceUpdate($update);
         }
 
         return NULL;
@@ -27,15 +27,16 @@ class ResourceUpdateController
 
     public function getResourceUpdates()
     {
+        Req::checkIdParam();
+
+        $updates = $this->database->getResourceUpdates(Req::id(), Req::page());
+        if (is_null($updates)) {
+            return NULL;
+        }
+
         $out = [];
-
-        if (Req::checkIdParam()) {
-            $updates = $this->database->getResourceUpdates($_GET['id'], Req::page());
-            if (is_null($updates)) return NULL;
-
-            foreach ($updates as $update) {
-                $out[] = new ResourceUpdate($update);
-            }
+        foreach ($updates as $update) {
+            $out[] = new ResourceUpdate($update);
         }
 
         return $out;

--- a/src/util/RequestUtil.php
+++ b/src/util/RequestUtil.php
@@ -29,6 +29,12 @@ class RequestUtil
         return $_GET['id'] ?? null;
     }
 
+    /**
+     * Checks if the 'id' parameter is present and valid.
+     * Exits with an error message if not.
+     *
+     * @return void
+     */
     public static function checkIdParam()
     {
         $id = self::id();
@@ -42,8 +48,6 @@ class RequestUtil
             echo new Error(400, "Invalid ID. ID must be numeric.");
             exit();
         }
-
-        return true;
     }
 
     public static function name()
@@ -51,6 +55,12 @@ class RequestUtil
         return $_GET['name'] ?? null;
     }
 
+    /**
+     * Checks if the 'name' parameter is present and valid.
+     * Exits with an error message if not.
+     *
+     * @return void
+     */
     public static function checkNameParam()
     {
         $name = self::name();
@@ -66,8 +76,6 @@ class RequestUtil
             echo new Error(400, "Invalid name. Name must be at 3-24 characters in length and consist of letters, numbers, and/or a limited set of special characters (_, -, ., and/or one or more spaces).");
             exit();
         }
-
-        return true;
     }
 
     public static function page()


### PR DESCRIPTION
The `checkIdParam()` and `checkNameParam()` functions (in RequestUtil.php) check that `id`/`name` is present and valid in the request parameters. If not, `exit()` is called. Only if everything is correct is `true` returned.
This means that only true is returned anyway. So you don't need a return type or an if check when calling the functions.

This PR removes the redundant `return true` from the functions and the if checks. PHPDoc also makes it clear that the functions call `exit()` independently if the necessary parameters are not present or are invalid.

This PR helps me prepare for my next planned changes, such as adding a pagination.