### PR TITLE
Add property `version_id` to `ResourceUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
 {
   "id":"352711",
   "resource_id":"6245",
+  "version_id":"348709",
   "resource_version":"2.10.9",  
   "download_count":282429,
   "post_date":1596535200,
@@ -347,6 +348,7 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
   {
     "id":"2",
     "resource_id":"2",
+    "version_id":"2",
     "resource_version":"1.0",
     "download_count":251,
     "post_date":1364382000,  
@@ -356,6 +358,7 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
   {
     "id":"17",
     "resource_id":"2",
+    "version_id":"18",
     "resource_version":"1.2.0",  
     "download_count":346,
     "post_date":1364468400,  
@@ -365,6 +368,7 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
   {
     "id":"66",
     "resource_id":"2",
+    "version_id":"67",
     "resource_version":"1.3.0",  
     "download_count":298,  
     "post_date":1365760800,  
@@ -374,6 +378,7 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
   {
     "id":"87",
     "resource_id":"2",
+    "version_id":"88",
     "resource_version":"1.3.2",
     "download_count":261,
     "post_date":1366279200,  
@@ -383,6 +388,7 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
   {
     "id":"119",
     "resource_id":"2",
+    "version_id":"120",
     "resource_version":"1.3.4",
     "download_count":971,
     "post_date":1366884000,  

--- a/src/object/ResourceUpdate.php
+++ b/src/object/ResourceUpdate.php
@@ -5,6 +5,7 @@ class ResourceUpdate
 {
     public $id;
     public $resource_id;
+    public $version_id;
     public $resource_version;
     public $download_count;
     public $post_date;
@@ -15,6 +16,7 @@ class ResourceUpdate
     {
         $this->id = $update['resource_update_id'];
         $this->resource_id = $update['resource_id'];
+        $this->version_id = $update['resource_version_id'];
         $this->resource_version = $update['version_string'];
         $this->download_count = $update['download_count'];
         $this->post_date = $update['post_date'];

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -252,6 +252,8 @@ components:
           type: integer
         resource_id:
           type: integer
+        version_id:
+          type: integer
         resource_version:
           type: string
         download_count:

--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -273,7 +273,7 @@ class Database
     private function _resource_update($suffix)
     {
         return sprintf(
-            "SELECT r.resource_update_id, r.resource_id, rv.version_string, rv.download_count, r.post_date, r.title, r.message
+            "SELECT r.resource_update_id, r.resource_id, rv.resource_version_id, rv.version_string, rv.download_count, r.post_date, r.title, r.message
             FROM xf_resource_update r
                 INNER JOIN xf_resource_version rv ON r.resource_update_id = rv.resource_update_id
             WHERE r.message_state = 'visible' %s",


### PR DESCRIPTION
Would be quite helpful as we neeed the `resource_version_id` (and not the `resource_update_id`) to download a file from `https://www.spigotmc.org/resources/<resource_id>/download?version=<resource_version_id>`