### PR TITLE
Filter non-visible resource versions

### DIFF
--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -276,7 +276,7 @@ class Database
             "SELECT r.resource_update_id, r.resource_id, rv.resource_version_id, rv.version_string, rv.download_count, r.post_date, r.title, r.message
             FROM xf_resource_update r
                 INNER JOIN xf_resource_version rv ON r.resource_update_id = rv.resource_update_id
-            WHERE r.message_state = 'visible' %s",
+            WHERE r.message_state = 'visible' AND rv.version_state = 'visible' %s",
             $suffix
         );
     }


### PR DESCRIPTION
This PR updates the `_resource_update` query to ensure that only updates with publicly visible versions are returned. 

The Issue:
In the XenForo Resource Manager, updates (`xf_resource_update`) and versions (`xf_resource_version`) can be managed independently. When a user deletes a version (via "Delete permanently" or "Remove from public view") the update entry itself remains 'visible'.

Currently, the API only checks for the state of the update with `r.message_state = 'visible'`. If a user deletes a version, the API still returns the update. However, attempting to download such a version (via the SpigotMC download URL) results in an error.

I changed the SQL query to include a check for the version state.
Now, if a resource version is not downloadable, it is no longer served by the API.