### PR TITLE
Add `order` and `direction` parameters to `listResources` and `getResourceUpdates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
 
 #### listResources
 ##### Parameters:
-| name 	    | type 	| required 	| default 	| description                                                                 	|
-|---------- |------	|----------	|---------	|-----------------------------------------------------------------------------	|
-| category  | int  	| no       	| none    	| The resource category to restrict results to (see `listResourceCategories`) 	|
-| page 	    | int  	| no       	| 1       	| The page number to retrieve. Items are paginated at 10 results per page.    	|
+| name 	      | type 	    | required 	| default 	   | description                                                                 	 |
+|-------------|-----------|----------	|-------------|-------------------------------------------------------------------------------|
+| category    | int  	    | no       	| none    	   | The resource category to restrict results to (see `listResourceCategories`) 	 |
+| page 	      | int  	    | no       	| 1       	   | The page number to retrieve. Items are paginated at 10 results per page.    	 |
+| order 	     | string 	 | no       	| id       	  | Field to order the results by.    	                                           |
+| direction 	 | string 	 | no       	| ASC       	 | Direction to order the results by.    	                                       |
 ##### Request: https://api.spigotmc.org/simple/0.2/index.php?action=listResources&category=4&page=2
 ##### Response (truncated):
 ```json
@@ -337,10 +339,12 @@ All requests must currently be sent via **GET** to https://api.spigotmc.org/simp
 
 #### getResourceUpdates
 ##### Parameters:
-| name 	| type 	| required 	| default 	| description                                                                 	|
-|------	|------	|----------	|---------	|-----------------------------------------------------------------------------	|
+| name 	| type 	| required 	| default 	| description                                                                 	 |
+|------	|------	|----------	|---------	|-------------------------------------------------------------------------------|
 | id  	| int  	| yes       | none    	| The id of the resource for which to retrieve updates                          |
-| page 	| int  	| no       	| 1       	| The page number to retrieve. Items are paginated at 10 results per page.    	|
+| page 	| int  	| no       	| 1       	| The page number to retrieve. Items are paginated at 10 results per page.    	 |
+| order 	     | string 	 | no       	| id       	  | Field to order the results by.                                                |
+| direction 	 | string 	 | no       	| ASC       	 | Direction to order the results by.                                            |
 ##### Request: https://api.spigotmc.org/simple/0.2/index.php?action=getResourceUpdates&id=2&page=1
 ##### Response (truncated):
 ```json

--- a/src/controller/ResourceController.php
+++ b/src/controller/ResourceController.php
@@ -17,7 +17,7 @@ class ResourceController
     {
         $out = [];
 
-        $resources = $this->database->listResources(Req::category(), Req::page());
+        $resources = $this->database->listResources(Req::category(), Req::page(), Req::order(), Req::direction());
 
         if (is_null($resources)) {
             return NULL;

--- a/src/controller/ResourceUpdateController.php
+++ b/src/controller/ResourceUpdateController.php
@@ -30,7 +30,7 @@ class ResourceUpdateController
         $out = [];
 
         if (Req::checkIdParam()) {
-            $updates = $this->database->getResourceUpdates($_GET['id'], Req::page());
+            $updates = $this->database->getResourceUpdates($_GET['id'], Req::page(), Req::order(), Req::direction());
             if (is_null($updates)) return NULL;
 
             foreach ($updates as $update) {

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -20,6 +20,26 @@ paths:
         required: false
         schema:
           type: integer
+      - name: order
+        description: Field to order the results by
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+           - id
+           - first_release
+           - last_update
+           - download_count
+      - name: direction
+        description: Direction to order the results by
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+            - asc
+            - desc
     get:
       operationId: listResources
       summary: Obtain a list of all resources
@@ -120,6 +140,25 @@ paths:
         required: false
         schema:
           type: integer
+      - name: order
+        description: Field to order the results by
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+            - id
+            - post_date
+            - download_count
+      - name: direction
+        description: Direction to order the results by
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+            - asc
+            - desc
     get:
       operationId: getResourceUpdates
       summary: Obtain all the updates to a resource

--- a/src/support/Database.php
+++ b/src/support/Database.php
@@ -41,13 +41,13 @@ class Database
         );
     }
 
-    public function listResources($category, $page)
+    public function listResources($category, $page, $order = null, $direction = null)
     {
         $page = $page == 1 ? 0 : 10 * ($page - 1);
 
         if (!is_null($this->conn)) {
             $categoryClause = is_null($category) ? '' : 'AND r.resource_category_id = :resource_category_id';
-            $resStmt = $this->_resource($categoryClause, 10, $page);
+            $resStmt = $this->_resource($categoryClause, 10, $page, $order, $direction);
 
             if (!empty($categoryClause)) {
                 $resStmt->bindParam(':resource_category_id', $category);
@@ -140,12 +140,12 @@ class Database
         return NULL;
     }
 
-    public function getResourceUpdates($resource_id, $page)
+    public function getResourceUpdates($resource_id, $page, $order = null, $direction = null)
     {
         $page = $page == 1 ? 0 : 10 * ($page - 1);
 
         if (!is_null($this->conn)) {
-            $updatesStmt = $this->_resource_update('AND r.resource_id = :resource_id', 10, $page);
+            $updatesStmt = $this->_resource_update('AND r.resource_id = :resource_id', 10, $page, $order, $direction);
             $updatesStmt->bindParam(':resource_id', $resource_id);
 
             if ($updatesStmt->execute()) {
@@ -213,8 +213,15 @@ class Database
         return NULL;
     }
 
-    private function _resource($additional_where_clauses, $limit = 1, $offset = null)
+    private function _resource($additional_where_clauses, $limit = 1, $offset = null, $order = null, $direction = null)
     {
+        $orderOptions = [
+            'id' => 'r.resource_id',
+            'first_release' => 'r.resource_date',
+            'last_update' => 'r.last_update',
+            'download_count' => 'r.download_count',
+        ];
+        $orderClause = $this->prepare_order_options($orderOptions, $order, $direction);
         $offsetClause = is_null($offset) ? '' : 'OFFSET :offset';
 
         $query = sprintf(
@@ -228,10 +235,11 @@ class Database
                     ON r.resource_category_id = rc.resource_category_id
             WHERE r.resource_state = 'visible' 
                   %s
-            ORDER BY r.resource_id ASC
+            %s
             LIMIT :limit 
             %s",
             $additional_where_clauses,
+            $orderClause,
             $offsetClause
         );
 
@@ -269,8 +277,14 @@ class Database
         return NULL;
     }
 
-    private function _resource_update($additional_where_clauses, $limit = 1, $offset = null)
+    private function _resource_update($additional_where_clauses, $limit = 1, $offset = null, $order = null, $direction = null)
     {
+        $orderOptions = [
+            'id' => 'r.resource_update_id',
+            'post_date' => 'r.post_date',
+            'download_count' => 'rv.download_count',
+        ];
+        $orderClause = $this->prepare_order_options($orderOptions, $order, $direction);
         $offsetClause = is_null($offset) ? '' : 'OFFSET :offset';
 
         $query = sprintf(
@@ -279,10 +293,11 @@ class Database
                 INNER JOIN xf_resource_version rv ON r.resource_update_id = rv.resource_update_id
             WHERE r.message_state = 'visible' AND rv.version_state = 'visible' 
                 %s
-            ORDER BY r.resource_update_id ASC
+            %s
             LIMIT :limit 
             %s",
             $additional_where_clauses,
+            $orderClause,
             $offsetClause
         );
 
@@ -294,5 +309,18 @@ class Database
         }
 
         return $stmt;
+    }
+
+    private function prepare_order_options($order_options, $order, $direction)
+    {
+        if (!empty($order) && array_key_exists($order, $order_options)) {
+            $column = $order_options[$order];
+        } else {
+            $column = array_shift($order_options);
+        }
+
+        $dir = strtolower($direction) === 'desc' ? 'DESC' : 'ASC';
+
+        return sprintf(' ORDER BY %s %s ', $column, $dir);
     }
 }

--- a/src/util/RequestUtil.php
+++ b/src/util/RequestUtil.php
@@ -91,4 +91,14 @@ class RequestUtil
 
         return NULL;
     }
+
+    public static function order()
+    {
+        return $_GET['order'] ?? null;
+    }
+
+    public static function direction()
+    {
+        return $_GET['direction'] ?? null;
+    }
 }


### PR DESCRIPTION
This PR adds the two parameters: `order` and `direction`.
These two parameters can be used with the actions: `listResources` and `getResourceUpdates`.
- `order` specifies the database field by which to sort, e.g., `id`, `post_date`, or `download_count`.
- `direction` specifies the sort order: `asc` for ascending (e.g., for IDs) or `desc` for descending (e.g., for dates such as `post_date`).

For the implementation, I took inspiration from the XenForo Resource Manager plugin. There, order options are also defined for each model using key-value pairs, as shown here, for example: 
```php
$orderOptions = [
  'id' => 'r.resource_id',
  'first_release' => 'r.resource_date',
  'last_update' => 'r.last_update',
  'download_count' => 'r.download_count',
];
```

By checking with `array_key_exists()` and retrieving the value from the array 
```php
$column = $order_options[$order];
```
we ensure that no SQL injection can occur via the `order` parameter.
If `order` is not specified or contains an invalid value, `array_shift()` is used to take the first entry from the `order_options` array. In both of these cases, it is the ID.
```php
$column = array_shift($order_options);
```


For `direction`, it’s even simpler: The functions checks whether `direction` is `desc`
```php
$dir = strtolower($direction) === 'desc' ? 'DESC' : 'ASC';
````
otherwise, it defaults to `'asc'`, so ascending order is the default.

Overall, this pull request adds the very useful feature to sort by IDs or dates (e.g., `last_update`). That would be very helpful for our purposes.